### PR TITLE
1. `frontend/index.html`: `backcast.py` → `wasm-intro.py`に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,12 @@ lerna-debug.log*
 node_modules/.tmp
 
 *.log
-backend/__marimo__/
-backend/backcast.py
 backend/layouts/backcast.slides.json
 backend/layouts/backcast.grid.json
 release/
 docs_org/
 .cursor/plans/
+.playwright-mcp/
+
+__marimo__/
+__tests__/

--- a/backend/run.py
+++ b/backend/run.py
@@ -36,16 +36,8 @@ def main():
         host = os.getenv("HOST", "127.0.0.1")
         
         # Notebook file path
-        notebook_file = server_dir / "backcast.py"
-        
-        # Ensure notebook file exists
-        if not notebook_file.exists():
-            print(f"Creating default notebook file: {notebook_file}")
-            notebook_file.parent.mkdir(parents=True, exist_ok=True)
-            notebook_file.write_text(
-                "# Backcast Notebook\n\nimport marimo\n\n__generated_with = \"0.18.4\"\napp = marimo.App()\n\n\n@app.cell\ndef _():\n    # Backcast Notebook\n    return\n\n\nif __name__ == \"__main__\":\n    app.run()\n",
-                encoding="utf-8"
-            )
+        # Use wasm-intro.py from frontend/public/files/ directory
+        notebook_file = server_dir.parent / "frontend" / "public" / "files" / "wasm-intro.py"
         
         # Create file router
         file_router = AppFileRouter.infer(str(notebook_file))

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,7 +10,7 @@ files:
   - dist/**
   - electron/**
   - backend/dist/**
-  - backend/backcast.py
+  - frontend/public/files/wasm-intro.py
   - backend/server-manager.js
   - package.json
   - "!**/*.{iml,o,hprof,orig,pyc,pyo,rbc,swp,csproj,sln,xproj}"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,7 +59,7 @@
         }
       }
     </script>
-    <marimo-filename hidden>backcast.py</marimo-filename>
+    <marimo-filename hidden>wasm-intro.py</marimo-filename>
     <marimo-version data-version="0.1.0" hidden></marimo-version>
     <marimo-user-config data-config="{}" hidden></marimo-user-config>
     <marimo-server-token data-token="" hidden></marimo-server-token>
@@ -71,7 +71,7 @@
     <div id="portal" data-testid="glide-portal" style="position: fixed; left: 0; top: 0; z-index: 9999"></div>
     <script data-marimo="true">
       window.__MARIMO_MOUNT_CONFIG__ = JSON.stringify({
-        filename: "backcast.py",
+        filename: "wasm-intro.py",
         mode: "edit",
         version: "0.1.0",
         config: {},


### PR DESCRIPTION
2. `backend/run.py`: `wasm-intro.py`を参照するように変更、自動生成ロジックを削除
3. `electron-builder.yml`: `backend/backcast.py`を削除、`frontend/public/files/wasm-intro.py`を追加
4. `backend/backcast.py`: ファイルを削除

### 動作確認結果
1. サーバーモード: `frontend/public/files/wasm-intro.py`が正しく読み込まれる
2. Electronビルド設定: `electron-builder.yml`に`frontend/public/files/wasm-intro.py`が含まれている
3. Pyodideモード: `wasm-intro.py`が正しく読み込まれる
4. デバッグログ: すべて削除済み

すべてのモードで`wasm-intro.py`に統一され、動作確認も完了しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default notebook file references across application configuration and backend runtime to use a new introductory notebook file.
  * Added build ignore patterns for temporary directories and test files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->