### PR TITLE
## 修正内容のまとめ

### DIFF
--- a/frontend/src/core/wasm/worker/bootstrap.ts
+++ b/frontend/src/core/wasm/worker/bootstrap.ts
@@ -82,13 +82,12 @@ export class DefaultWasmController implements WasmController {
         
         # Install marimo-base wheel without dependency resolution
         # This allows us to use Pyodide's default msgspec (0.18.6)
-        if "${wheel}".startswith("http"):
-            await micropip.install("${wheel}", deps=False)
-        else:
-            await micropip.install("${wheel}", deps=False)
+        wheel_url = "${wheel}"
+        await micropip.install(wheel_url, deps=False)
         
         # Manually install required dependencies
         # msgspec is already loaded from Pyodide (0.18.6), which satisfies >=0.18.6
+        # Install other dependencies that marimo-base needs
         await micropip.install("narwhals>=2.0.0")
       `);
 


### PR DESCRIPTION
### 問題
- `msgspec>=0.20.0`のpure Python wheelがPyodideで利用できない
- Pyodideのデフォルト`msgspec`（0.18.6）と`marimo-base`の要件（`msgspec>=0.20.0`）が競合

### 解決策
1. Pyodideのデフォルト`msgspec`（0.18.6）を使用
   - `packages`配列に`msgspec`を含める（既に実装済み）
2. `marimo-base`を`deps=False`でインストール
   - 依存関係の解決をスキップし、wheelを直接インストール
3. 必要な依存関係を手動でインストール
   - `narwhals>=2.0.0`を手動でインストール

### 修正後のコード
```typescript
const packages = [
  "micropip",
  "msgspec",  // Pyodide's default (0.18.6)
  "packaging",
];

// Install marimo-base without dependency resolution
await micropip.install(wheel_url, deps=False)

// Manually install required dependencies
await micropip.install("narwhals>=2.0.0")
```

### 次のステップ
1. 変更をコミット・プッシュ
2. GitHub Actionsで再デプロイ
3. デプロイ後、https://backcast-pro.web.app/ で動作確認

`deps=False`が正しく動作すれば、`msgspec>=0.20.0`のエラーは回避できるはずです。デプロイ後に動作を確認してください。

## 📝 Summary

<!--
Provide a concise summary of what this pull request is addressing.

If this PR closes any issues, list them here by number (e.g., Closes #123).
-->
Closes #

## 🔍 Description of Changes

<!--
Detail the specific changes made in this pull request. Explain the problem addressed and how it was resolved. If applicable, provide before and after comparisons, screenshots, or any relevant details to help reviewers understand the changes easily.
-->

## 📋 Checklist

- [ ] I have read the [contributor guidelines](https://github.com/marimo-team/marimo/blob/main/CONTRIBUTING.md).
- [ ] For large changes, or changes that affect the public API: this change was discussed or approved through an issue, on [Discord](https://marimo.io/discord?ref=pr), or the community [discussions](https://github.com/marimo-team/marimo/discussions) (Please provide a link if applicable).
- [ ] Tests have been added for the changes made.
- [ ] Documentation has been updated where applicable, including docstrings for API changes.
- [ ] Pull request title is a good summary of the changes - it will be used in the [release notes](https://github.com/marimo-team/marimo/releases).
